### PR TITLE
Join Multiple Recipe Category Options with "or"

### DIFF
--- a/TitanSchoolsClient.js
+++ b/TitanSchoolsClient.js
@@ -136,7 +136,8 @@ class TitanSchoolsClient {
               .map((recipeCategory) => {
                 return recipeCategory.Recipes.map(
                   (recipe) => recipe.RecipeName
-                );
+                )
+                .join(" or ");
               })
               .join(", ")
           };


### PR DESCRIPTION
- Join category options with "or" instead of ","

My school district has multiple options for some recipe categories, ie "White Milk or Chocolate Milk" and as far as I know, the students are allowed only 1 option.

This PR changes the listing of the recipe category options from showing as:

```
Today:
  Breakfast: Cinnamon Pancake, Fresh Grapes,Pears,23 - Fruit Apple slices ind. pkg.,Fresh Apple,Peaches, White Milk,Chocolate Milk
  Lunch: Italian Dunkers,Sweet & Sour Chicken, Mandarin Oranges, Steamed Broccoli, White Milk,Chocolate Milk

Tomorrow:
  Breakfast: Berry Bites, Fresh Juicy Orange,Fresh Banana, White Milk,Chocolate Milk
  Lunch: Bento Box,Chicken Nuggets, Fresh Grapes, Fresh Baby Carrots,Potato Wedges, White Milk,Chocolate Milk
```

To use "or" to join the options

```plain
Today:
  Breakfast: Cinnamon Pancake, Fresh Grapes or Pears or 23 - Fruit Apple slices ind. pkg. or Fresh Apple or Peaches, White Milk or Chocolate Milk
  Lunch: Italian Dunkers or Sweet & Sour Chicken, Mandarin Oranges, Steamed Broccoli, White Milk or Chocolate Milk

Tomorrow:
  Breakfast: Berry Bites, Fresh Juicy Orange or Fresh Banana, White Milk or Chocolate Milk
  Lunch: Bento Box or Chicken Nuggets, Fresh Grapes, Fresh Baby Carrots or Potato Wedges, White Milk or Chocolate Milk
```

<details><summary>Example from titan website</summary>

Breakfast:

![Breakfast](https://user-images.githubusercontent.com/1580378/188952804-5837e31f-ca2d-4105-9f7e-62c1b7a5b7b6.png)

Lunch:

![Lunch](https://user-images.githubusercontent.com/1580378/188952844-ca57cbbc-0359-43c4-a871-47106bfaeecd.png)

</details>