### PR TITLE
Updated API domain from titank12 to api.linqconnect.com and handled schema changes

### DIFF
--- a/MMM-TitanSchoolMealMenu.js
+++ b/MMM-TitanSchoolMealMenu.js
@@ -5,14 +5,15 @@ Module.register("MMM-TitanSchoolMealMenu", {
     numberOfDaysToDisplay: 3,
     size: "medium",
     recipeCategoriesToInclude: [
-      "Main Entree",
+      "Entrees",
       "Grain"
       //   , "Fruit"
       //   , "Vegetable"
       //   , "Milk"
       //   , "Condiment"
       //   , "Extra"
-    ]
+    ],
+    debug: false
   },
 
   requiresVersion: "2.1.0", // Required version of MagicMirror
@@ -33,7 +34,8 @@ Module.register("MMM-TitanSchoolMealMenu", {
       buildingId: this.config.buildingId,
       districtId: this.config.districtId,
       recipeCategoriesToInclude: this.config.recipeCategoriesToInclude,
-      instanceName: this.instanceName
+      instanceName: this.instanceName,
+      debug: this.config.debug
     });
 
     // Schedule update timer

--- a/node_helper.js
+++ b/node_helper.js
@@ -53,7 +53,8 @@ module.exports = NodeHelper.create({
       self.titanSchoolsClients[payload.instanceName] = new TitanSchoolsClient({
         buildingId: payload.buildingId,
         districtId: payload.districtId,
-        recipeCategoriesToInclude: payload.recipeCategoriesToInclude
+        recipeCategoriesToInclude: payload.recipeCategoriesToInclude,
+        debug: payload.debug,
       });
       this.sendSocketNotification(
         `TITANSCHOOLS_CLIENT_READY::${payload.instanceName}`


### PR DESCRIPTION
# Changes
- Updated the API domain from `family.titank12.com` to `api.linqconnect.com`
- Accounted for a schema change to the `/FamilyMenu` API response (`.MenuMeals[0]?.RecipeCategories[0]?.Recipes[0]`)
- Fixed the `debug: true` configuration parameter. You can now enable verbose logging for this module by setting `debug: true` in this module's section of the `config.js` file.

Resolves #5 
