### PR TITLE
More Days to Display, Hide Empty Days/Meals, Allow all Categories, Today Styling, Show Current Week

### DIFF
--- a/MMM-TitanSchoolMealMenu.js
+++ b/MMM-TitanSchoolMealMenu.js
@@ -4,6 +4,11 @@ Module.register("MMM-TitanSchoolMealMenu", {
     updateIntervalMs: 60 * 60 * 1000, // milliseconds
     numberOfDaysToDisplay: 3,
     size: "medium",
+    todayClass: "large",
+    displayCurrentWeek: false,
+    weekStartsOnMonday: false,
+    hideEmptyDays: false,
+    hideEmptyMeals: false,
     recipeCategoriesToInclude: [
       "Entrees",
       "Grain"
@@ -29,13 +34,8 @@ Module.register("MMM-TitanSchoolMealMenu", {
 
     // Send the module config to the node_helper
     this.broadcastConfig({
-      retryDelayMs: this.config.retryDelayMs,
-      updateIntervalMs: this.config.updateIntervalMs,
-      buildingId: this.config.buildingId,
-      districtId: this.config.districtId,
-      recipeCategoriesToInclude: this.config.recipeCategoriesToInclude,
-      instanceName: this.instanceName,
-      debug: this.config.debug
+      ...this.config,
+      instanceName: this.instanceName
     });
 
     // Schedule update timer
@@ -110,12 +110,13 @@ Module.register("MMM-TitanSchoolMealMenu", {
       const meals = document.createElement("ul");
       meals.className = `meal-list ${this.config.size || ""}`;
       this.dataNotification.forEach((dayMenu, index) => {
-        if (index >= this.config.numberOfDaysToDisplay) {
+        if (this.config.hideEmptyDays && !dayMenu.breakfast && !dayMenu.lunch) {
           return;
         }
 
         // Day list item.
         const dayListItem = document.createElement("li");
+        dayListItem.className = dayMenu.label == 'Today' ? this.config.todayClass || "" : "";
         const dayLabel = document.createElement("span");
         dayLabel.className = "day-label";
         dayLabel.innerHTML = dayMenu.label;
@@ -123,38 +124,42 @@ Module.register("MMM-TitanSchoolMealMenu", {
         meals.appendChild(dayListItem);
 
         // Breakfast.
-        const breakfastMenuList = document.createElement("ul");
-        const breakfastMenuItems = document.createElement("li");
-        const breakfastMenuTitle = document.createElement("span");
-        const breakfastMenuRecipes = document.createElement("span");
+        if (dayMenu.breakfast || !this.config.hideEmptyMeals) {
+          const breakfastMenuList = document.createElement("ul");
+          const breakfastMenuItems = document.createElement("li");
+          const breakfastMenuTitle = document.createElement("span");
+          const breakfastMenuRecipes = document.createElement("span");
 
-        breakfastMenuTitle.innerHTML = "Breakfast: ";
-        breakfastMenuTitle.className = "meal-title";
-        breakfastMenuRecipes.innerHTML = dayMenu.breakfast ?? "none";
-        breakfastMenuRecipes.className = "meal-recipes";
+          breakfastMenuTitle.innerHTML = "Breakfast: ";
+          breakfastMenuTitle.className = "meal-title";
+          breakfastMenuRecipes.innerHTML = dayMenu.breakfast ?? "none";
+          breakfastMenuRecipes.className = "meal-recipes";
 
-        breakfastMenuList.className = "meal-description";
-        breakfastMenuList.appendChild(breakfastMenuItems);
-        breakfastMenuItems.appendChild(breakfastMenuTitle);
-        breakfastMenuItems.appendChild(breakfastMenuRecipes);
-        dayListItem.appendChild(breakfastMenuList);
+          breakfastMenuList.className = "meal-description";
+          breakfastMenuList.appendChild(breakfastMenuItems);
+          breakfastMenuItems.appendChild(breakfastMenuTitle);
+          breakfastMenuItems.appendChild(breakfastMenuRecipes);
+          dayListItem.appendChild(breakfastMenuList);
+        }
 
         // Lunch.
-        const lunchMenuList = document.createElement("ul");
-        const lunchMenuItems = document.createElement("li");
-        const lunchMenuTitle = document.createElement("span");
-        const lunchMenuRecipes = document.createElement("span");
+        if (dayMenu.lunch || !this.config.hideEmptyMeals) {
+          const lunchMenuList = document.createElement("ul");
+          const lunchMenuItems = document.createElement("li");
+          const lunchMenuTitle = document.createElement("span");
+          const lunchMenuRecipes = document.createElement("span");
 
-        lunchMenuTitle.innerHTML = "Lunch: ";
-        lunchMenuTitle.className = "meal-title";
-        lunchMenuRecipes.innerHTML = dayMenu.lunch ?? "none";
-        lunchMenuRecipes.className = "meal-recipes";
+          lunchMenuTitle.innerHTML = "Lunch: ";
+          lunchMenuTitle.className = "meal-title";
+          lunchMenuRecipes.innerHTML = dayMenu.lunch ?? "none";
+          lunchMenuRecipes.className = "meal-recipes";
 
-        lunchMenuList.className = "meal-description";
-        lunchMenuList.appendChild(lunchMenuItems);
-        lunchMenuItems.appendChild(lunchMenuTitle);
-        lunchMenuItems.appendChild(lunchMenuRecipes);
-        dayListItem.appendChild(lunchMenuList);
+          lunchMenuList.className = "meal-description";
+          lunchMenuList.appendChild(lunchMenuItems);
+          lunchMenuItems.appendChild(lunchMenuTitle);
+          lunchMenuItems.appendChild(lunchMenuRecipes);
+          dayListItem.appendChild(lunchMenuList);
+        }
       });
 
       wrapperDataNotification.appendChild(meals);

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MMM-TitanSchoolMealMenu
 
-A module for the MagicMirror framework that retrieves a school meal menu from the LinqConnect API (api.linqconnect.com). LinqConnect was formerly known as "Titan Schools" (family.titank12.com).
+A module for the [MagicMirror²](https://github.com/MagicMirrorOrg/MagicMirror) framework that retrieves a school meal menu from the LinqConnect API (api.linqconnect.com). LinqConnect was formerly known as "Titan Schools" (family.titank12.com).
 
 ---
 
@@ -8,76 +8,108 @@ A module for the MagicMirror framework that retrieves a school meal menu from th
 
 ## Install
 
-```
+Clone `MMM-TitanSchoolMealMenu` into the modules folder of your MagicMirror² installation:
+
+```bash
 cd ~/MagicMirror/modules
-git clone https://github.com/evanhsu/MMM-TitanSchoolMealMenu.git
+git clone https://github.com/evanhsu/MMM-TitanSchoolMealMenu
+npm install
 ```
 
 ## Update
 
-```
+Go to the `MMM-TitanSchoolMealMenu` folder inside MagicMirror² modules folder and pull the latest version from GitHub:
+
+```bash
 cd ~/MagicMirror/modules/MMM-TitanSchoolMealMenu
 git pull
+npm install
 ```
+
+Restart MagicMirror² after updating.
 
 ## Usage
 
-Add this to your MagicMirror `config.js`:
+Add this to your MagicMirror² `config.js`:
 
-    {
-        module: "MMM-TitanSchoolMealMenu",
-        position: "top_left",
-        header: "School Menu",
-        config: {
-            size: 'medium', // Optional: 'small', 'medium', 'large'; Default: 'medium'
-            buildingId: '23125610-cbbc-eb11-a2cb-82fe13669c55',
-            districtId: '93f76ff0-2eb7-eb11-a2c4-e816644282bd',
-            updateIntervalMs: 3600000, // Optional: Milliseconds between updates; Default: 3600000 (1 hour)
-            numberOfDaysToDisplay: 3, // Optional: 0 - 5; Default: 3
-            recipeCategoriesToInclude: [
-                "Entrees",
-                "Grain"
-                // , "Fruit"
-                // , "Vegetable"
-                // , "Milk"
-                // , "Condiment"
-                // , "Extra"
-            ],
-            debug: false // Optional: boolean; Default: false; Setting this to true will output verbose logs
-        },
+```javascript
+{
+    module: "MMM-TitanSchoolMealMenu",
+    position: "top_left",
+    header: "School Menu",
+    config: {
+        size: 'medium', // Optional: 'small', 'medium', 'large'; Default: 'medium'
+        buildingId: '23125610-cbbc-eb11-a2cb-82fe13669c55',
+        districtId: '93f76ff0-2eb7-eb11-a2c4-e816644282bd',
+        updateIntervalMs: 3600000, // Optional: Milliseconds between updates; Default: 3600000 (1 hour)
+        numberOfDaysToDisplay: 3, // Optional: 0 - 5; Default: 3
+        recipeCategoriesToInclude: [
+            "Entrees",
+            "Grain"
+            // , "Fruit"
+            // , "Vegetable"
+            // , "Milk"
+            // , "Condiment"
+            // , "Extra"
+        ],
+        debug: false // Optional: boolean; Default: false; Setting this to true will output verbose logs
     },
+},
+```
 
 You can also track multiple school menus by listing the module multiple times in your `config.js` file (each config will probably have a different `buildingId`/`districtId`):
 
-    {
-        module: "MMM-TitanSchoolMealMenu",
-        position: "top_right",
-        header: "The Derek Zoolander Center for Kids Who Can't Read Good and Wanna Learn to Do Other Stuff Good Too.",
-        config: {
-            buildingId: '7833a90f-a4bc-eb11-a2cb-8711b287b526',
-            districtId: '93f76ff0-2eb7-eb11-a2c4-e816644282bd',
-        },
+```javascript
+{
+    module: "MMM-TitanSchoolMealMenu",
+    position: "top_right",
+    header: "The Derek Zoolander Center for Kids Who Can't Read Good and Wanna Learn to Do Other Stuff Good Too.",
+    config: {
+        buildingId: '7833a90f-a4bc-eb11-a2cb-8711b287b526',
+        districtId: '93f76ff0-2eb7-eb11-a2c4-e816644282bd',
     },
-    {
-        module: "MMM-TitanSchoolMealMenu",
-        position: "top_left",
-        header: "School for Kid #1",
-        config: {
-            buildingId: "9017b6ae-a3bc-eb11-a2cb-82fe13669c55",
-            districtId: "93f76ff0-2eb7-eb11-a2c4-e816644282bd",
-        }
-    },
+},
+{
+    module: "MMM-TitanSchoolMealMenu",
+    position: "top_left",
+    header: "School for Kid #1",
+    config: {
+        buildingId: "9017b6ae-a3bc-eb11-a2cb-82fe13669c55",
+        districtId: "93f76ff0-2eb7-eb11-a2c4-e816644282bd",
+    }
+},
+```
 
 ![Multiple Schools](./docs/multiple-schools.png)
+
+### Options
+
+These are the possible options:
+
+| Option                          | Description    |
+|---------------------------------|----------------|
+| `buildingId`                    | <p>The buildingId found on the LinqConnect webpage.</p><p>**REQUIRED**<br>**Type:** `string`<br>**Example:** `"23125610-cbbc-eb11-a2cb-82fe13669c55"`<br>**Default value:** none</p><p>**NOTE:** See [Finding your `buildingId` and `districtId`](#finding-your-buildingid-and-districtid) below</p>|
+| `districtId`                    | <p>The districtId found on the LinqConnect webpage.</p><p>**REQUIRED**<br>**Type:** `string`<br>**Example:** `"93f76ff0-2eb7-eb11-a2c4-e816644282bd"`<br>**Default value:** none</p><p>**NOTE:** See [Finding your `buildingId` and `districtId`](#finding-your-buildingid-and-districtid) below</p>|
+| `retryDelayMs`                  | <p>How long to wait to retry after an error from the API.</p><p>**Type:** `integer`<br>**Possible values:** `0` - `?`<br>**Default value:** `20000` (20 seconds)<br>**Unit:** `milliseconds`</p>|
+| `updateIntervalMs`              | <p>The time in milliseconds when the menu should be updated.</p><p>**Type:** `integer`<br>**Possible values:** `0` - `?`<br>**Default value:** `3600000` (1 hour)<br>**Unit:** `milliseconds`</p>|
+| `numberOfDaysToDisplay`         | <p>The number of days to display menu items.</p><p>**Type:** `integer`<br>**Possible values:** `0` - `?`<br>**Example:** `5`<br>**Default value:** `3`<br>**Unit:** `days`</p><p>**Note:** If `displayCurrentWeek` is `true`, this will be the number of days after the first day of the week, not today.</p>|
+| `size`                          | <p>The css class for the font size.</p><p>**Type:** `string`<br>**Possible values:** `x-small`, `small`, `medium`, `large`, `xlarge`<br>**Example:** `"small"`<br>**Default value:** `medium`</p><p>**Note:** You can use any css class here, not just font sizes.</p>|
+| `todayClass`                    | <p>The css class for today's meal.</p><p>**Type:** `string`<br>**Possible values:** `x-small`, `small`, `medium`, `large`, `xlarge`<br>**Example:** `"medium bright"`<br>**Default value:** `large`</p><p>**Note:** You can use any css class here, not just font sizes.</p>|
+| `displayCurrentWeek`            | <p>Display meals starting from the first day of the week instead of today.</p><p>**Type:** `boolean`<br>**Default value:** `false`<br>**Possible values:** `true` and `false`|
+| `weekStartsOnMonday`            | <p>Show Monday as the first day of the week. Set to `true` to show Monday as the first day of the week.</p><p>**Type:** `boolean`<br>**Default value:** `false`<br>**Possible values:** `true` and `false`|
+| `hideEmptyDays`                 | <p>Hide days without any meals.</p><p>**Type:** `boolean`<br>**Default value:** `false`<br>**Possible values:** `true` and `false`|
+| `hideEmptyMeals`                | <p>Hide meals that are empty.</p><p>**Type:** `boolean`<br>**Default value:** `false`<br>**Possible values:** `true` and `false`|
+| `recipeCategoriesToInclude`     | <p>An array of recipe categories to display.</p><p>**Type:** `array`<br>**Example:** `[ "Entrees", "Grain", "Fruit", "Vegetable" ]`<br>**Default value:** `[ "Entrees", "Grain" ]`<br>**Possible values:** Any valid category in the API as an array. (See example)</p><p>**Note:** Your district might not use the categories in this module. You will need to find the categories by visting the website.</p><p>**Note 2:** If this is blank (`[]`), all categories will be selected.</p>|
+| `debug`                         | <p>Setting this to `true` will output verbose logs.</p><p>**Type:** `boolean`<br>**Default value:** `false`<br>**Possible values:** `true` and `false`|
 
 ---
 
 ## Finding your `buildingId` and `districtId`
 
-#### 1. Go to the LinqConnect webpage and search for your school district: https://linqconnect.com/
+1. Go to the LinqConnect webpage and search for your school district: <https://linqconnect.com/>
 
 ![Search for your school district](./docs/step1.png)
 
-#### 2. Select your school from the dropdown and use your browser's developer tools to inspect the resulting request to the `/FamilyMenu` endpoint. The `districtId` and `buildingId` will be present as query string parameters on this requests.
+2. Select your school from the dropdown and use your browser's developer tools to inspect the resulting request to the `/FamilyMenu` endpoint. The `districtId` and `buildingId` will be present as query string parameters on this requests.
 
 ![Use developer tools to inspect a network request](./docs/step2.png)

--- a/TitanSchoolsClient.js
+++ b/TitanSchoolsClient.js
@@ -1,5 +1,4 @@
 const axios = require("axios").default;
-const moment = require("moment");
 
 /**
  * A _very_ lightweight client for the TitanSchools API.
@@ -50,8 +49,8 @@ class TitanSchoolsClient {
   /**
    * Fetches menu data from the TitanSchools API and formats it as shown below
    *
-   * @param Moment startDate (Optional) A Moment object that specifies which day the menu should start on
-   * @param Moment endDate (Optional) A Moment object that specifies which day the menu should end on
+   * @param Date startDate A Date object that specifies which day the menu should start on
+   * @param Date endDate A Date object that specifies which day the menu should end on
    * @throws Error If the TitanSchools API responds with a 400- or 500-level HTTP status
    *
    * @returns An array of meals shaped like this (starting on {startDate} and including {config.numberOfDaysToDisplay} days):
@@ -83,22 +82,16 @@ class TitanSchoolsClient {
    *   }
    * ]
    */
-  async fetchMenu(startDate = null, endDate = null) {
+  async fetchMenu(startDate, endDate) {
     let params = {
       ...this.requestParams,
-      // If no startDate was provided, use today's date
-      // API requires date to be formatted as: m-d-Y (i.e. 12-5-2021)
-      startDate: this.formatDate(startDate ?? moment()),
-      endDate: this.formatDate(endDate ?? moment().add(7, "days"))
+      // API requires dates to be formatted as: m-d-Y (i.e. 12-5-2021)
+      startDate: this.formatDate(startDate),
+      endDate: this.formatDate(endDate)
     };
 
     if (this.debug) {
-      if (startDate === null) {
-        console.debug("Using today as startDate");
-      } else {
-        console.debug(`Using ${startDate.format("MM-DD-YYYY")} as startDate`);
-      }
-      console.debug(`Using ${endDate.format("MM-DD-YYYY")} as endDate`);
+      console.debug(`Using ${params.startDate} as startDate, ${params.endDate} as endDate`);
 
       // Log the outbound API request
       this.client.interceptors.request.use((request) => {
@@ -137,11 +130,13 @@ class TitanSchoolsClient {
 
   /**
    *
-   * @param Moment dateObject A moment object
+   * @param Date dateObject A Date object
    * @returns string A date string formatted as m-d-Y (1-9-2023)
    */
   formatDate(dateObject) {
-    return `${dateObject.format("MM-DD-YYYY")}`
+    return `${
+      dateObject.getMonth() + 1 // javascript month is 0-indexed :facepalm:
+    }-${dateObject.getDate()}-${dateObject.getFullYear()}`;
   }
 
   /**

--- a/node_helper.js
+++ b/node_helper.js
@@ -1,6 +1,5 @@
 const NodeHelper = require("node_helper");
 const TitanSchoolsClient = require("./TitanSchoolsClient");
-const moment = require("moment");
 
 module.exports = NodeHelper.create({
   // Subclass start method.
@@ -23,12 +22,12 @@ module.exports = NodeHelper.create({
       return;
     }
 
-    const days = this.config.numberOfDaysToDisplay;
     const startDate = this.config.displayCurrentWeek
       ? getFirstDayOfWeek(this.config.weekStartsOnMonday)
-      : moment();
-    
-    const endDate = startDate.clone().add(days, "days");
+      : new Date(Date.now());
+
+    var endDate = new Date(Date.now());
+    endDate.setDate(startDate.getDate() + this.config.numberOfDaysToDisplay);
 
     try {
       //   const menu = await this.titanSchoolsClient.fetchMockMenu();
@@ -97,22 +96,19 @@ function isObjectEmpty(obj) {
 }
 
 function getFirstDayOfWeek(weekStartsOnMonday) {
-  const today = moment();
-  let firstDayOfWeek = moment();
+  const today = new Date();
+  const dayOfWeek = today.getDay(); // 0-6, where 0 is Sunday.
 
-  // moment.isoWeekday() returns 1 for Monday, 7 for Sunday.
+  let firstDayOfWeek = new Date(today);
+
   if (weekStartsOnMonday) {
-    const weekStartedDaysAgo = today.isoWeekday() - 1;
-    firstDayOfWeek = today.subtract(weekStartedDaysAgo, "days");
+    const daysToSubtract = dayOfWeek === 0 ? 6 : dayOfWeek - 1;
+    firstDayOfWeek.setDate(today.getDate() - daysToSubtract);
   } else {
-    const weekday = today.isoWeekday();
-
-    if (weekday === 7) {
-      firstDayOfWeek = today;
-    } else {
-      firstDayOfWeek = today.subtract(weekday, "days");
-    }
+    firstDayOfWeek.setDate(today.getDate() - dayOfWeek);
   }
 
-  return firstDayOfWeek.startOf("day");
+  firstDayOfWeek.setHours(0, 0, 0, 0);  // Set time to start of day.
+
+  return firstDayOfWeek;
 }


### PR DESCRIPTION
- Add ability to style today's meal `todayClass`
- Add ability to show meals starting at the beginning of the week `displayCurrentWeek`
- Change `numberOfDaysToDisplay` to allow more than 5 days
- Add ability to hide days with no meals `hideEmptyDays`
- Add ability to hide meals with no items `hideEmptyMeals`
- Allow `recipeCategoriesToInclude` to be blank to select all
- Update readme and add config options